### PR TITLE
Update documentation to use Just the Docs theme

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,7 +30,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
-          bundler-cache: false
+          bundler-cache: true
           
       - name: Install dependencies
         run: |

--- a/docs/01_command_line_interface.md
+++ b/docs/01_command_line_interface.md
@@ -1,4 +1,11 @@
-# Chapter 1: Command Line Interface
+---
+layout: default
+title: Command Line Interface
+nav_order: 2
+permalink: /cli/
+---
+
+# Command Line Interface
 
 Imagine you have a complex machine with many buttons and settings, but you want a simple, intuitive way to control it. That's exactly what a Command Line Interface (CLI) does for our repository ingestion system!
 

--- a/docs/02_pipeline_integration.md
+++ b/docs/02_pipeline_integration.md
@@ -1,6 +1,13 @@
-# Chapter 2: Pipeline Integration
+---
+layout: default
+title: Pipeline Integration
+nav_order: 3
+permalink: /pipeline/
+---
 
-In the [previous chapter about the Command Line Interface](01_command_line_interface.md), we learned how to interact with our tool using simple commands. Now, let's dive into the heart of our system: the Pipeline Integration.
+# Pipeline Integration
+
+In the [previous chapter about the Command Line Interface](/cli/), we learned how to interact with our tool using simple commands. Now, let's dive into the heart of our system: the Pipeline Integration.
 
 ## The Pipeline: Your Content Processing Maestro 🎼
 

--- a/docs/03_firecrawl_integration.md
+++ b/docs/03_firecrawl_integration.md
@@ -1,6 +1,13 @@
-# Chapter 3: Firecrawl Integration
+---
+layout: default
+title: Firecrawl Integration
+nav_order: 4
+permalink: /firecrawl/
+---
 
-In the [previous chapter about Pipeline Integration](02_pipeline_integration.md), we learned how to process repository content systematically. Now, let's explore an exciting capability that transforms our tool from a simple repository processor into an intelligent web researcher: Firecrawl Integration!
+# Firecrawl Integration
+
+In the [previous chapter about Pipeline Integration](/pipeline/), we learned how to process repository content systematically. Now, let's explore an exciting capability that transforms our tool from a simple repository processor into an intelligent web researcher: Firecrawl Integration!
 
 ## The Web Research Challenge 🕵️‍♀️
 

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,12 +1,29 @@
 source "https://rubygems.org"
 
-gem "jekyll", "~> 3.9.3", group: :jekyll_plugins
+gem "jekyll", "~> 4.3.2"
+gem "just-the-docs", "~> 0.7.0"
 gem "webrick", "~> 1.8"
 gem "kramdown-parser-gfm"
-gem "jekyll-theme-cayman", "~> 0.2.0"
 
 group :jekyll_plugins do
-  gem "jekyll-feed"
-  gem "jekyll-seo-tag"
-  gem "jekyll-sitemap"
+  gem "jekyll-feed", "~> 0.17.0"
+  gem "jekyll-seo-tag", "~> 2.8.0"
+  gem "jekyll-sitemap", "~> 1.4.0"
 end
+
+# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
+# and associated library.
+platforms :mingw, :x64_mingw, :mswin, :jruby do
+  gem "tzinfo", ">= 1", "< 3"
+  gem "tzinfo-data"
+end
+
+# Performance-booster for watching directories on Windows
+gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+
+# Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
+# do not have a Java counterpart.
+gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
+
+# Lock jekyll-sass-converter to 2.x on Linux/macOS
+gem "jekyll-sass-converter", "~> 2.0"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,18 +1,27 @@
 title: Pinecone MCP Helper
 description: An intelligent repository ingestion pipeline that transforms code and web content into searchable vector databases
-theme: jekyll-theme-cayman
 
 # GitHub Pages settings
 baseurl: "/pinecone-mcp-helper"
 url: "https://decision-crafters.github.io"
 
 # Build settings
+theme: just-the-docs
+remote_theme: just-the-docs/just-the-docs@v0.7.0
 markdown: kramdown
 highlighter: rouge
 
-# Navigation
-header_pages:
-  - index.md
+# Just the Docs configuration
+color_scheme: light
+search_enabled: true
+heading_anchors: true
+permalink: pretty
+
+# Enable copy code button
+enable_copy_code_button: true
+
+# Footer content
+footer_content: "Copyright &copy; 2025 Decision Crafters. Distributed under an MIT license."
 
 # Exclude from processing
 exclude:
@@ -23,6 +32,18 @@ exclude:
 # Enable Mermaid diagrams
 mermaid:
   enable: true
+
+# Aux links for the upper right navigation
+aux_links:
+  "Pinecone MCP Helper on GitHub":
+    - "https://github.com/decision-crafters/pinecone-mcp-helper"
+
+# Makes Aux links open in a new tab
+aux_links_new_tab: true
+
+# Back to top link
+back_to_top: true
+back_to_top_text: "Back to top"
 
 # Collections
 collections:

--- a/docs/adr/0001-use-firecrawl-sdk.md
+++ b/docs/adr/0001-use-firecrawl-sdk.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: Use Firecrawl SDK Instead of MCP Functions
+parent: Architecture Decision Records
+nav_order: 1
+---
+
 # Use Firecrawl SDK Instead of MCP Functions
 
 ## Status

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,3 +1,11 @@
+---
+layout: default
+title: Architecture Decision Records
+nav_order: 12
+has_children: true
+permalink: /adr/
+---
+
 # Architecture Decision Records
 
 This section contains the Architecture Decision Records (ADRs) for the Pinecone MCP Helper project. ADRs are used to document important architectural decisions, their context, and consequences.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,25 @@
 ---
-layout: default
-title: Pinecone MCP Helper
+layout: home
+title: Home
+nav_order: 1
+description: "Pinecone MCP Helper - An intelligent repository ingestion pipeline that transforms code and web content into searchable vector databases"
+permalink: /
 ---
 
-# Tutorial: pinecone-mcp-helper
+# Pinecone MCP Helper
+{: .fs-9 }
 
-**Pinecone MCP Helper** is an intelligent *repository ingestion pipeline* that transforms code and web content into searchable vector databases. It automates the process of extracting, embedding, and indexing content from Git repositories and web sources, enabling powerful semantic search and research capabilities using Pinecone's vector database technology.
+An intelligent repository ingestion pipeline that transforms code and web content into searchable vector databases.
+{: .fs-6 .fw-300 }
+
+[Get started now](#getting-started){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[View it on GitHub](https://github.com/decision-crafters/pinecone-mcp-helper){: .btn .fs-5 .mb-4 .mb-md-0 }
+
+---
+
+## Overview
+
+**Pinecone MCP Helper** is an intelligent repository ingestion pipeline that transforms code and web content into searchable vector databases. It automates the process of extracting, embedding, and indexing content from Git repositories and web sources, enabling powerful semantic search and research capabilities using Pinecone's vector database technology.
 
 
 **Source Repository:** [https://github.com/decision-crafters/pinecone-mcp-helper.git](https://github.com/decision-crafters/pinecone-mcp-helper.git)
@@ -33,18 +47,29 @@ flowchart TD
     A8 -- "Triggers pipeline" --> A0
 ```
 
-## Chapters
+## Getting Started
+{: #getting-started }
 
-1. [Command Line Interface](01_command_line_interface.md)
-2. [Pipeline Integration](02_pipeline_integration.md)
-3. [Firecrawl Integration](03_firecrawl_integration.md)
-4. [Repository Processing](04_repository_processing.md)
-5. [Embedding Transformation](05_embedding_transformation.md)
-6. [Pinecone Vector Management](06_pinecone_vector_management.md)
-7. [Configuration Management](07_configuration_management.md)
-8. [Validation and Quality Assurance](08_validation_and_quality_assurance.md)
-9. [Logging and Error Handling](09_logging_and_error_handling.md)
-10. [Real-World Examples](10_real_world_examples.md)
+To get started with Pinecone MCP Helper, follow these steps:
+
+1. Install the package
+2. Configure your Pinecone API key
+3. Run your first ingestion pipeline
+
+## Documentation Sections
+
+Browse through our documentation to learn more about specific features and capabilities:
+
+1. [Command Line Interface](01_command_line_interface.html)
+2. [Pipeline Integration](02_pipeline_integration.html)
+3. [Firecrawl Integration](03_firecrawl_integration.html)
+4. [Repository Processing](04_repository_processing.html)
+5. [Embedding Transformation](05_embedding_transformation.html)
+6. [Pinecone Vector Management](06_pinecone_vector_management.html)
+7. [Configuration Management](07_configuration_management.html)
+8. [Validation and Quality Assurance](08_validation_and_quality_assurance.html)
+9. [Logging and Error Handling](09_logging_and_error_handling.html)
+10. [Real-World Examples](10_real_world_examples.html)
 
 
 ---


### PR DESCRIPTION
This PR updates the documentation to use the Just the Docs theme for better navigation, search capabilities, and organization.

Changes include:
- Updated _config.yml to use Just the Docs theme
- Added Just the Docs dependencies to Gemfile
- Updated documentation files with proper frontmatter
- Added navigation structure with nav_order and permalinks
- Updated internal links to use the new permalink structure
- Set up parent-child relationships for ADR section
- Updated GitHub workflow for better caching

This approach maintains the existing content while improving the documentation organization and user experience.